### PR TITLE
feat: show repl_time as seconds per MB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2788,8 +2788,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -2807,13 +2806,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2826,18 +2823,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -2940,8 +2934,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -2951,7 +2944,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -2964,20 +2956,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -2994,7 +2983,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3067,8 +3055,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3078,7 +3065,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3154,8 +3140,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3185,7 +3170,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3203,7 +3187,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3242,13 +3225,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -6117,8 +6098,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6136,13 +6116,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6155,18 +6133,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6269,8 +6244,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6280,7 +6254,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6293,20 +6266,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6323,7 +6293,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6396,8 +6365,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6407,7 +6375,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6483,8 +6450,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6514,7 +6480,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6532,7 +6497,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6571,13 +6535,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,8 @@ import bronze from './bronze.png'
 const API_URL = process.env.REACT_APP_API_URL || '/leaderboard.json'
 const REFRESH_INTERVAL = process.env.REACT_APP_REFRESH_INTERVAL || 10 * 1000
 
+const secondsToMicroseconds = (s) => numeral(s * 1e+6).format(0,0)
+
 const Header = () => (
   <header className="mw7 center">
     <h1 className='ma0 pv4 fw2 f1 montserrat tc'>
@@ -34,7 +36,7 @@ const Entry = ({name, time}) => {
     <div className='flex'>
       <Avatar name={name} />
       <span className='fw5 montserrat white truncate flex-auto' title={name}>{name}</span>
-      <ReplTime time={numeral(time).format('0.000e+0')} />
+      <ReplTime time={secondsToMicroseconds(time)} />
     </div>
   )
 }
@@ -108,7 +110,7 @@ class App extends Component {
           <div className='mw7 pl3 center pb2 cf'>
             <h2 className='f4 f3-m f3-l mv3 pl4-m pl4-l tc tl-m tl-l montserrat fw2 ttu fl-m fl-l'>Leaderboard</h2>
             <div className='f4 f3-m f3-l mv3 pr4 fr'>
-              <div className='f6 f5-m f5-l mt1 montserrat fw2'>Time / byte (ms)</div>
+              <div className='f6 f5-m f5-l mt1 montserrat fw2' title='microseconds per byte'>Time / byte <small>(µs)</small> </div>
             </div>
           </div>
           <ol className='ma0 lh-copy mw7 mb5 pl3 center db gray' style={{listStyleType: 'decimal'}}>

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react'
-import numeral from 'numeral'
 import logo from './filecoin-logo.svg'
 import gold from './gold.png'
 import silver from './silver.png'
@@ -7,8 +6,6 @@ import bronze from './bronze.png'
 
 const API_URL = process.env.REACT_APP_API_URL || '/leaderboard.json'
 const REFRESH_INTERVAL = process.env.REACT_APP_REFRESH_INTERVAL || 10 * 1000
-
-const secondsToMicroseconds = (s) => numeral(s * 1e+6).format(0,0)
 
 const Header = () => (
   <header className="mw7 center">
@@ -36,7 +33,7 @@ const Entry = ({name, time}) => {
     <div className='flex'>
       <Avatar name={name} />
       <span className='fw5 montserrat white truncate flex-auto' title={name}>{name}</span>
-      <ReplTime time={secondsToMicroseconds(time)} />
+      <ReplTime time={time.toFixed(3)} />
     </div>
   )
 }
@@ -92,8 +89,8 @@ class App extends Component {
     }
 
     const data = leaderboardData
-      .map(d => ({ ...d, perByteTime: (d.repl_time * 1000) / d.params.size }))
-      .sort((a, b) => a.perByteTime - b.perByteTime)
+      .map(d => ({ ...d, secondsPerMBTime: d.repl_time / (d.params.size / 1e+6) }))
+      .sort((a, b) => a.secondsPerMBTime - b.secondsPerMBTime)
       .reduce((deduped, d) => {
         const exists = deduped.some(dd => {
           return dd.prover === d.prover &&
@@ -110,46 +107,46 @@ class App extends Component {
           <div className='mw7 pl3 center pb2 cf'>
             <h2 className='f4 f3-m f3-l mv3 pl4-m pl4-l tc tl-m tl-l montserrat fw2 ttu fl-m fl-l'>Leaderboard</h2>
             <div className='f4 f3-m f3-l mv3 pr4 fr'>
-              <div className='f6 f5-m f5-l mt1 montserrat fw2' title='microseconds per byte'>Time / byte <small>(µs)</small> </div>
+              <div className='f6 f5-m f5-l mt1 montserrat fw2' title='microseconds per byte'>Repl time <small >(s/MB)</small></div>
             </div>
           </div>
           <ol className='ma0 lh-copy mw7 mb5 pl3 center db gray' style={{listStyleType: 'decimal'}}>
-          {data.slice(0,1).map(({ id, prover, perByteTime, params }) => (
+          {data.slice(0,1).map(({ id, prover, secondsPerMBTime, params }) => (
             <li
               key={id}
               className='tl f4 mh3 pa3 b--gold b--solid bw1 br3 relative shadow-1'
               style={{ backgroundColor: 'rgba(255, 183, 0, 0.75)' }}
               title={formatParams(params)}>
               <Medal type='gold' />
-              <Entry name={prover} time={perByteTime} />
+              <Entry name={prover} time={secondsPerMBTime} />
             </li>
           ))}
-          {data.slice(1,2).map(({ id, prover, perByteTime, params }) => (
+          {data.slice(1,2).map(({ id, prover, secondsPerMBTime, params }) => (
             <li
               key={id}
               className='tl f4 mt4 mh3 pa3 b--silver b--solid bw1 br3 relative shadow-1'
               style={{ backgroundColor: 'rgba(153, 153, 153, 0.75)' }}
               title={formatParams(params)}>
               <Medal type='silver' />
-              <Entry name={prover} time={perByteTime} />
+              <Entry name={prover} time={secondsPerMBTime} />
             </li>
           ))}
-          {data.slice(2,3).map(({ id, prover, perByteTime, params }) => (
+          {data.slice(2,3).map(({ id, prover, secondsPerMBTime, params }) => (
             <li
               key={id}
               className='tl f4 mt4 mh3 mb4 pa3 b--solid bw1 br3 relative shadow-1'
               style={{ borderColor: '#cd7f32', backgroundColor: 'rgba(205, 127, 50, 0.75)' }}
               title={formatParams(params)}>
               <Medal type='bronze' />
-              <Entry name={prover} time={perByteTime} />
+              <Entry name={prover} time={secondsPerMBTime} />
             </li>
           ))}
-          {data.slice(3).map(({ id, prover, perByteTime, params }) => (
+          {data.slice(3).map(({ id, prover, secondsPerMBTime, params }) => (
             <li
               key={id}
               className='tl mt3 mh3 ph3 f4'
               title={formatParams(params)}>
-              <Entry name={prover} time={perByteTime} />
+              <Entry name={prover} time={secondsPerMBTime} />
             </li>
           ))}
           </ol>


### PR DESCRIPTION
using microseconds gives us numbers in a range that is much easier
to reason about as human.

<img width="1108" alt="screenshot 2019-03-01 at 10 50 32" src="https://user-images.githubusercontent.com/58871/53633597-deb39d80-3c0f-11e9-8afe-203221a13fba.png">


License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>