### PR TITLE
refactor: show 4 leaderboards

### DIFF
--- a/public/leaderboard.json
+++ b/public/leaderboard.json
@@ -1,8 +1,68 @@
 [
   {
-    "id": 9,
-    "prover": "porcuquine",
+    "id": 125,
+    "prover": "Whyrusleeping",
     "repl_time": 0,
+    "params": {
+      "id": 390812100441266750,
+      "typ": "Zigzag",
+      "size": 1024,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 165,
+    "prover": "rjan90",
+    "repl_time": 1,
+    "params": {
+      "id": 390812100441266750,
+      "typ": "Zigzag",
+      "size": 1024,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 120,
+    "prover": "Whyrusleeping",
+    "repl_time": 1,
+    "params": {
+      "id": -2901411057259781000,
+      "typ": "DrgPoRep",
+      "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 162,
+    "prover": "rjan90",
+    "repl_time": 1,
+    "params": {
+      "id": -2901411057259781000,
+      "typ": "DrgPoRep",
+      "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 166,
+    "prover": "rjan90",
+    "repl_time": 1,
     "params": {
       "id": -2822207868961647600,
       "typ": "Zigzag",
@@ -15,13 +75,13 @@
     }
   },
   {
-    "id": 18,
-    "prover": "porcuquine",
+    "id": 123,
+    "prover": "Whyrusleeping",
     "repl_time": 1,
     "params": {
-      "id": -8973295860119922000,
+      "id": -2822207868961647600,
       "typ": "Zigzag",
-      "size": 4096,
+      "size": 10240,
       "challenge_count": 2,
       "vde": 0,
       "degree": 6,
@@ -45,7 +105,7 @@
     }
   },
   {
-    "id": 10,
+    "id": 122,
     "prover": "porcuquine",
     "repl_time": 3,
     "params": {
@@ -60,9 +120,99 @@
     }
   },
   {
+    "id": 117,
+    "prover": "Whyrusleeping",
+    "repl_time": 3,
+    "params": {
+      "id": 2875142023595730400,
+      "typ": "Zigzag",
+      "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 164,
+    "prover": "rjan90",
+    "repl_time": 4,
+    "params": {
+      "id": -3754677902270980600,
+      "typ": "DrgPoRep",
+      "size": 10485760,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 119,
+    "prover": "Whyrusleeping",
+    "repl_time": 4,
+    "params": {
+      "id": -3754677902270980600,
+      "typ": "DrgPoRep",
+      "size": 10485760,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 139,
+    "prover": "lt",
+    "repl_time": 4,
+    "params": {
+      "id": 390812100441266750,
+      "typ": "Zigzag",
+      "size": 1024,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
     "id": 20,
     "prover": "eli",
     "repl_time": 4,
+    "params": {
+      "id": 2875142023595730400,
+      "typ": "Zigzag",
+      "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 158,
+    "prover": "rjan90",
+    "repl_time": 5,
+    "params": {
+      "id": 2875142023595730400,
+      "typ": "Zigzag",
+      "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 159,
+    "prover": "rjan90",
+    "repl_time": 5,
     "params": {
       "id": 2875142023595730400,
       "typ": "Zigzag",
@@ -90,9 +240,144 @@
     }
   },
   {
+    "id": 155,
+    "prover": "rjan90",
+    "repl_time": 5,
+    "params": {
+      "id": 2875142023595730400,
+      "typ": "Zigzag",
+      "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 157,
+    "prover": "rjan90",
+    "repl_time": 5,
+    "params": {
+      "id": 2875142023595730400,
+      "typ": "Zigzag",
+      "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
     "id": 13,
     "prover": "jbenet",
     "repl_time": 5,
+    "params": {
+      "id": 2875142023595730400,
+      "typ": "Zigzag",
+      "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 156,
+    "prover": "rjan90",
+    "repl_time": 5,
+    "params": {
+      "id": 2875142023595730400,
+      "typ": "Zigzag",
+      "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 68,
+    "prover": "tianru13",
+    "repl_time": 6,
+    "params": {
+      "id": 2875142023595730400,
+      "typ": "Zigzag",
+      "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 66,
+    "prover": "tianru11",
+    "repl_time": 6,
+    "params": {
+      "id": 2875142023595730400,
+      "typ": "Zigzag",
+      "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 67,
+    "prover": "tianru12",
+    "repl_time": 6,
+    "params": {
+      "id": 2875142023595730400,
+      "typ": "Zigzag",
+      "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 127,
+    "prover": "liuy",
+    "repl_time": 6,
+    "params": {
+      "id": 2875142023595730400,
+      "typ": "Zigzag",
+      "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 128,
+    "prover": "liuy",
+    "repl_time": 6,
+    "params": {
+      "id": 2875142023595730400,
+      "typ": "Zigzag",
+      "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 14,
+    "prover": "jbenett",
+    "repl_time": 6,
     "params": {
       "id": 2875142023595730400,
       "typ": "Zigzag",
@@ -135,66 +420,6 @@
     }
   },
   {
-    "id": 68,
-    "prover": "tianru13",
-    "repl_time": 6,
-    "params": {
-      "id": 2875142023595730400,
-      "typ": "Zigzag",
-      "size": 1048576,
-      "challenge_count": 2,
-      "vde": 0,
-      "degree": 6,
-      "expansion_degree": 6,
-      "layers": 10
-    }
-  },
-  {
-    "id": 14,
-    "prover": "jbenett",
-    "repl_time": 6,
-    "params": {
-      "id": 2875142023595730400,
-      "typ": "Zigzag",
-      "size": 1048576,
-      "challenge_count": 2,
-      "vde": 0,
-      "degree": 6,
-      "expansion_degree": 6,
-      "layers": 10
-    }
-  },
-  {
-    "id": 67,
-    "prover": "tianru12",
-    "repl_time": 6,
-    "params": {
-      "id": 2875142023595730400,
-      "typ": "Zigzag",
-      "size": 1048576,
-      "challenge_count": 2,
-      "vde": 0,
-      "degree": 6,
-      "expansion_degree": 6,
-      "layers": 10
-    }
-  },
-  {
-    "id": 66,
-    "prover": "tianru11",
-    "repl_time": 6,
-    "params": {
-      "id": 2875142023595730400,
-      "typ": "Zigzag",
-      "size": 1048576,
-      "challenge_count": 2,
-      "vde": 0,
-      "degree": 6,
-      "expansion_degree": 6,
-      "layers": 10
-    }
-  },
-  {
     "id": 15,
     "prover": "pizzaparty",
     "repl_time": 7,
@@ -202,6 +427,21 @@
       "id": 2875142023595730400,
       "typ": "Zigzag",
       "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 126,
+    "prover": "Whyrusleeping",
+    "repl_time": 7,
+    "params": {
+      "id": 7307213965081976000,
+      "typ": "Zigzag",
+      "size": 2097152,
       "challenge_count": 2,
       "vde": 0,
       "degree": 6,
@@ -225,8 +465,8 @@
     }
   },
   {
-    "id": 57,
-    "prover": "blackfirefly",
+    "id": 132,
+    "prover": "孙慧娟",
     "repl_time": 8,
     "params": {
       "id": 2875142023595730400,
@@ -255,9 +495,129 @@
     }
   },
   {
-    "id": 60,
-    "prover": "tianru02",
-    "repl_time": 9,
+    "id": 57,
+    "prover": "blackfirefly",
+    "repl_time": 8,
+    "params": {
+      "id": 2875142023595730400,
+      "typ": "Zigzag",
+      "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 140,
+    "prover": "IPFS原力区",
+    "repl_time": 8,
+    "params": {
+      "id": 2875142023595730400,
+      "typ": "Zigzag",
+      "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 131,
+    "prover": "IPFS原力区",
+    "repl_time": 8,
+    "params": {
+      "id": 2875142023595730400,
+      "typ": "Zigzag",
+      "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 130,
+    "prover": "IPFS原力区",
+    "repl_time": 8,
+    "params": {
+      "id": 2875142023595730400,
+      "typ": "Zigzag",
+      "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 129,
+    "prover": "IPFS原力区",
+    "repl_time": 8,
+    "params": {
+      "id": 2875142023595730400,
+      "typ": "Zigzag",
+      "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 138,
+    "prover": "lt",
+    "repl_time": 8,
+    "params": {
+      "id": 2875142023595730400,
+      "typ": "Zigzag",
+      "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 109,
+    "prover": "孙慧娟",
+    "repl_time": 8,
+    "params": {
+      "id": 2875142023595730400,
+      "typ": "Zigzag",
+      "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 108,
+    "prover": "孙慧娟",
+    "repl_time": 8,
+    "params": {
+      "id": 2875142023595730400,
+      "typ": "Zigzag",
+      "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 133,
+    "prover": "孙慧娟",
+    "repl_time": 8,
     "params": {
       "id": 2875142023595730400,
       "typ": "Zigzag",
@@ -272,6 +632,21 @@
   {
     "id": 56,
     "prover": "IPFSFund",
+    "repl_time": 9,
+    "params": {
+      "id": 2875142023595730400,
+      "typ": "Zigzag",
+      "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 60,
+    "prover": "tianru02",
     "repl_time": 9,
     "params": {
       "id": 2875142023595730400,
@@ -300,6 +675,66 @@
     }
   },
   {
+    "id": 142,
+    "prover": "axin",
+    "repl_time": 10,
+    "params": {
+      "id": 2875142023595730400,
+      "typ": "Zigzag",
+      "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 124,
+    "prover": "Whyrusleeping",
+    "repl_time": 10,
+    "params": {
+      "id": 3818173106873232000,
+      "typ": "Zigzag",
+      "size": 4194304,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 160,
+    "prover": "rjan90",
+    "repl_time": 11,
+    "params": {
+      "id": 7307213965081976000,
+      "typ": "Zigzag",
+      "size": 2097152,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 161,
+    "prover": "rjan90",
+    "repl_time": 14,
+    "params": {
+      "id": 3818173106873232000,
+      "typ": "Zigzag",
+      "size": 4194304,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
     "id": 19,
     "prover": "eli",
     "repl_time": 15,
@@ -315,7 +750,7 @@
     }
   },
   {
-    "id": 100,
+    "id": 99,
     "prover": "ipfs原力区",
     "repl_time": 19,
     "params": {
@@ -345,7 +780,7 @@
     }
   },
   {
-    "id": 99,
+    "id": 100,
     "prover": "ipfs原力区",
     "repl_time": 19,
     "params": {
@@ -390,6 +825,36 @@
     }
   },
   {
+    "id": 136,
+    "prover": "sunhuijuan",
+    "repl_time": 24,
+    "params": {
+      "id": 2875142023595730400,
+      "typ": "Zigzag",
+      "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 135,
+    "prover": "sunhuijuan",
+    "repl_time": 24,
+    "params": {
+      "id": 2875142023595730400,
+      "typ": "Zigzag",
+      "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
     "id": 101,
     "prover": "ipfs原力区",
     "repl_time": 26,
@@ -405,7 +870,157 @@
     }
   },
   {
-    "id": 112,
+    "id": 118,
+    "prover": "Whyrusleeping",
+    "repl_time": 28,
+    "params": {
+      "id": -6035303110978460000,
+      "typ": "Zigzag",
+      "size": 10485760,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 7,
+    "prover": "porcuquine",
+    "repl_time": 31,
+    "params": {
+      "id": -6035303110978460000,
+      "typ": "Zigzag",
+      "size": 10485760,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 5,
+    "prover": "porcuquine",
+    "repl_time": 31,
+    "params": {
+      "id": -6035303110978460000,
+      "typ": "Zigzag",
+      "size": 10485760,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 4,
+    "prover": "porcuquine",
+    "repl_time": 31,
+    "params": {
+      "id": -6035303110978460000,
+      "typ": "Zigzag",
+      "size": 10485760,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 115,
+    "prover": "porcuquine",
+    "repl_time": 31,
+    "params": {
+      "id": -6035303110978460000,
+      "typ": "Zigzag",
+      "size": 10485760,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 18,
+    "prover": "porcuquine",
+    "repl_time": 31,
+    "params": {
+      "id": -6035303110978460000,
+      "typ": "Zigzag",
+      "size": 10485760,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 10,
+    "prover": "porcuquine",
+    "repl_time": 31,
+    "params": {
+      "id": -6035303110978460000,
+      "typ": "Zigzag",
+      "size": 10485760,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 9,
+    "prover": "porcuquine",
+    "repl_time": 31,
+    "params": {
+      "id": -6035303110978460000,
+      "typ": "Zigzag",
+      "size": 10485760,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 8,
+    "prover": "porcuquine",
+    "repl_time": 31,
+    "params": {
+      "id": -6035303110978460000,
+      "typ": "Zigzag",
+      "size": 10485760,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 6,
+    "prover": "porcuquine",
+    "repl_time": 31,
+    "params": {
+      "id": -6035303110978460000,
+      "typ": "Zigzag",
+      "size": 10485760,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 111,
     "prover": "Ipfs原力区",
     "repl_time": 35,
     "params": {
@@ -420,7 +1035,7 @@
     }
   },
   {
-    "id": 111,
+    "id": 112,
     "prover": "Ipfs原力区",
     "repl_time": 35,
     "params": {
@@ -495,6 +1110,21 @@
     }
   },
   {
+    "id": 168,
+    "prover": "rjan90",
+    "repl_time": 41,
+    "params": {
+      "id": -6035303110978460000,
+      "typ": "Zigzag",
+      "size": 10485760,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
     "id": 106,
     "prover": "zfl",
     "repl_time": 41,
@@ -502,6 +1132,21 @@
       "id": -2420357494704776700,
       "typ": "DrgPoRep",
       "size": 1024,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 137,
+    "prover": "孙慧娟",
+    "repl_time": 50,
+    "params": {
+      "id": -6035303110978460000,
+      "typ": "Zigzag",
+      "size": 10485760,
       "challenge_count": 2,
       "vde": 0,
       "degree": 6,
@@ -562,6 +1207,66 @@
       "id": -2901411057259781000,
       "typ": "DrgPoRep",
       "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 143,
+    "prover": "axin",
+    "repl_time": 52,
+    "params": {
+      "id": -6035303110978460000,
+      "typ": "Zigzag",
+      "size": 10485760,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 134,
+    "prover": "shj",
+    "repl_time": 52,
+    "params": {
+      "id": -6035303110978460000,
+      "typ": "Zigzag",
+      "size": 10485760,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 141,
+    "prover": "IPFS原力区",
+    "repl_time": 52,
+    "params": {
+      "id": -6035303110978460000,
+      "typ": "Zigzag",
+      "size": 10485760,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 144,
+    "prover": "shj",
+    "repl_time": 52,
+    "params": {
+      "id": -6035303110978460000,
+      "typ": "Zigzag",
+      "size": 10485760,
       "challenge_count": 2,
       "vde": 0,
       "degree": 6,
@@ -705,6 +1410,51 @@
     }
   },
   {
+    "id": 154,
+    "prover": "suzakinishi",
+    "repl_time": 222,
+    "params": {
+      "id": 390812100441266750,
+      "typ": "Zigzag",
+      "size": 1024,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 163,
+    "prover": "rjan90",
+    "repl_time": 317,
+    "params": {
+      "id": 8586938920904822000,
+      "typ": "DrgPoRep",
+      "size": 1073741824,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 116,
+    "prover": "Whyrusleeping",
+    "repl_time": 317,
+    "params": {
+      "id": 8586938920904822000,
+      "typ": "DrgPoRep",
+      "size": 1073741824,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
     "id": 89,
     "prover": "LiFei",
     "repl_time": 322,
@@ -727,6 +1477,21 @@
       "id": 2875142023595730400,
       "typ": "Zigzag",
       "size": 1048576,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 121,
+    "prover": "Whyrusleeping",
+    "repl_time": 345,
+    "params": {
+      "id": -185733344676357660,
+      "typ": "Zigzag",
+      "size": 104857600,
       "challenge_count": 2,
       "vde": 0,
       "degree": 6,
@@ -765,6 +1530,111 @@
     }
   },
   {
+    "id": 148,
+    "prover": "xjxh.io",
+    "repl_time": 491,
+    "params": {
+      "id": 390812100441266750,
+      "typ": "Zigzag",
+      "size": 1024,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 145,
+    "prover": "xjxh.io",
+    "repl_time": 491,
+    "params": {
+      "id": 390812100441266750,
+      "typ": "Zigzag",
+      "size": 1024,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 146,
+    "prover": "xjxh.io",
+    "repl_time": 491,
+    "params": {
+      "id": 390812100441266750,
+      "typ": "Zigzag",
+      "size": 1024,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 147,
+    "prover": "xjxh.io",
+    "repl_time": 491,
+    "params": {
+      "id": 390812100441266750,
+      "typ": "Zigzag",
+      "size": 1024,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 149,
+    "prover": "xjxh.io",
+    "repl_time": 491,
+    "params": {
+      "id": 390812100441266750,
+      "typ": "Zigzag",
+      "size": 1024,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 150,
+    "prover": "xjxh.io",
+    "repl_time": 491,
+    "params": {
+      "id": 390812100441266750,
+      "typ": "Zigzag",
+      "size": 1024,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 151,
+    "prover": "xjxh.io",
+    "repl_time": 491,
+    "params": {
+      "id": 390812100441266750,
+      "typ": "Zigzag",
+      "size": 1024,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
     "id": 105,
     "prover": "Sunhuijuan",
     "repl_time": 492,
@@ -780,6 +1650,21 @@
     }
   },
   {
+    "id": 167,
+    "prover": "rjan90",
+    "repl_time": 540,
+    "params": {
+      "id": -185733344676357660,
+      "typ": "Zigzag",
+      "size": 104857600,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
     "id": 91,
     "prover": "LiFei",
     "repl_time": 566,
@@ -787,6 +1672,21 @@
       "id": 7967971959614620000,
       "typ": "Zigzag",
       "size": 10240000,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 152,
+    "prover": "xjxh.io",
+    "repl_time": 608,
+    "params": {
+      "id": 2875142023595730400,
+      "typ": "Zigzag",
+      "size": 1048576,
       "challenge_count": 2,
       "vde": 0,
       "degree": 6,
@@ -885,6 +1785,21 @@
     }
   },
   {
+    "id": 153,
+    "prover": "xjxh.io",
+    "repl_time": 715,
+    "params": {
+      "id": -2822207868961647600,
+      "typ": "Zigzag",
+      "size": 10240,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
     "id": 58,
     "prover": "ReadyPlayerOne",
     "repl_time": 779,
@@ -892,36 +1807,6 @@
       "id": 2875142023595730400,
       "typ": "Zigzag",
       "size": 1048576,
-      "challenge_count": 2,
-      "vde": 0,
-      "degree": 6,
-      "expansion_degree": 6,
-      "layers": 10
-    }
-  },
-  {
-    "id": 109,
-    "prover": "孙慧娟",
-    "repl_time": 933,
-    "params": {
-      "id": 8586938920904822000,
-      "typ": "DrgPoRep",
-      "size": 1073741824,
-      "challenge_count": 2,
-      "vde": 0,
-      "degree": 6,
-      "expansion_degree": 6,
-      "layers": 10
-    }
-  },
-  {
-    "id": 108,
-    "prover": "孙慧娟",
-    "repl_time": 933,
-    "params": {
-      "id": 8586938920904822000,
-      "typ": "DrgPoRep",
-      "size": 1073741824,
       "challenge_count": 2,
       "vde": 0,
       "degree": 6,
@@ -1020,84 +1905,9 @@
     }
   },
   {
-    "id": 8,
-    "prover": "porcuquine",
-    "repl_time": 2379,
-    "params": {
-      "id": 8939453956850745000,
-      "typ": "Zigzag",
-      "size": 1073741824,
-      "challenge_count": 2,
-      "vde": 0,
-      "degree": 6,
-      "expansion_degree": 6,
-      "layers": 10
-    }
-  },
-  {
-    "id": 5,
-    "prover": "porcuquine",
-    "repl_time": 2379,
-    "params": {
-      "id": 8939453956850745000,
-      "typ": "Zigzag",
-      "size": 1073741824,
-      "challenge_count": 2,
-      "vde": 0,
-      "degree": 6,
-      "expansion_degree": 6,
-      "layers": 10
-    }
-  },
-  {
-    "id": 4,
-    "prover": "porcuquine",
-    "repl_time": 2379,
-    "params": {
-      "id": 8939453956850745000,
-      "typ": "Zigzag",
-      "size": 1073741824,
-      "challenge_count": 2,
-      "vde": 0,
-      "degree": 6,
-      "expansion_degree": 6,
-      "layers": 10
-    }
-  },
-  {
-    "id": 6,
-    "prover": "porcuquine",
-    "repl_time": 2379,
-    "params": {
-      "id": 8939453956850745000,
-      "typ": "Zigzag",
-      "size": 1073741824,
-      "challenge_count": 2,
-      "vde": 0,
-      "degree": 6,
-      "expansion_degree": 6,
-      "layers": 10
-    }
-  },
-  {
-    "id": 7,
-    "prover": "porcuquine",
-    "repl_time": 2379,
-    "params": {
-      "id": 8939453956850745000,
-      "typ": "Zigzag",
-      "size": 1073741824,
-      "challenge_count": 2,
-      "vde": 0,
-      "degree": 6,
-      "expansion_degree": 6,
-      "layers": 10
-    }
-  },
-  {
     "id": 2,
     "prover": "Whyrusleeping",
-    "repl_time": 2494,
+    "repl_time": 2317,
     "params": {
       "id": 8939453956850745000,
       "typ": "Zigzag",
@@ -1147,6 +1957,21 @@
       "id": 7307213965081976000,
       "typ": "Zigzag",
       "size": 2097152,
+      "challenge_count": 2,
+      "vde": 0,
+      "degree": 6,
+      "expansion_degree": 6,
+      "layers": 10
+    }
+  },
+  {
+    "id": 169,
+    "prover": "rjan90",
+    "repl_time": 3332,
+    "params": {
+      "id": 8939453956850745000,
+      "typ": "Zigzag",
+      "size": 1073741824,
       "challenge_count": 2,
       "vde": 0,
       "degree": 6,

--- a/src/App.js
+++ b/src/App.js
@@ -2,10 +2,7 @@
 
 import React, { Component } from 'react'
 import logo from './filecoin-logo.svg'
-import Leaderboard from './Leaderboard'
-
-const API_URL = process.env.REACT_APP_API_URL || 'leaderboard.json'
-const REFRESH_INTERVAL = process.env.REACT_APP_REFRESH_INTERVAL || 10 * 1000
+import LeaderboardList from './LeaderboardList'
 
 const Header = () => (
   <header className='mw7 center'>
@@ -16,66 +13,15 @@ const Header = () => (
   </header>
 )
 
-function processLeaderboardData (data) {
-  data = data.map(d => ({ ...d, secondsPerMBTime: d.repl_time / (d.params.size / (1024 * 1024)) }))
-
-  // Group leaderboard by params ID - { id: [entries] }
-  const groups = data.reduce((groups, d) => {
-    groups[d.params.id] = (groups[d.params.id] || []).concat(d)
-    return groups
-  }, {})
-
-  // [[leaderboard], [leaderboard]]
-  return Object.values(groups)
-    .filter(l => l.length > 1) // Not really a leaderboard if only 1 person...
-    .sort((a, b) => b.length - a.length)
-    .map(board => board.sort((a, b) => a.secondsPerMBTime - b.secondsPerMBTime))
-}
-
 class App extends Component {
   state = {}
 
-  componentDidMount () {
-    const refresh = async () => {
-      try {
-        const res = await fetch(API_URL)
-        if (!res.ok) throw new Error(`unexpected status ${res.status}`)
-        this.setState({ leaderboardData: await res.json() })
-      } catch (err) {
-        console.error('failed to fetch leaderboard data', err)
-      } finally {
-        setTimeout(refresh, REFRESH_INTERVAL)
-      }
-    }
-    refresh()
-  }
-
   render () {
-    const { leaderboardData } = this.state
-
-    if (!leaderboardData) {
-      return (
-        <div className='sans-serif white'>
-          <Header />
-          <main className='tc'>
-            <p>Loading...</p>
-          </main>
-        </div>
-      )
-    }
-
-    const leaderboards = processLeaderboardData(leaderboardData)
-
     return (
       <div className='sans-serif white'>
         <Header />
         <main>
-          <div className='mw7 pl3 center pb2 cf'>
-            <h2 className='f4 f3-m f3-l mv3 pl4-m pl4-l tc tl-m tl-l montserrat fw2 ttu fl-m fl-l'>Leaderboards</h2>
-          </div>
-          <div className='mw7 pl3 center pb2 cf'>
-            {leaderboards.map(l => <Leaderboard entries={l} />)}
-          </div>
+          <LeaderboardList />
         </main>
       </div>
     )

--- a/src/LeaderboardList.js
+++ b/src/LeaderboardList.js
@@ -1,0 +1,103 @@
+/* eslint-env browser */
+
+import React, { Component, Fragment } from 'react'
+import Leaderboard from './Leaderboard'
+
+const API_URL = process.env.REACT_APP_API_URL || 'leaderboard.json'
+const REFRESH_INTERVAL = process.env.REACT_APP_REFRESH_INTERVAL || 10 * 1000
+
+// These are the param sets for leaderboards that should be shown at the top
+const TOP_BOARD_PARAM_IDS = [
+  -6035303110978460000, // Zigzag 10MB
+  -3754677902270980600, // DrgPoRep 10MB
+  8939453956850745000, // Zigzag 1GB
+  8586938920904822000 // DrgPoRep 1GB
+]
+
+function processBoardData (data) {
+  data = data.map(d => ({ ...d, secondsPerMBTime: d.repl_time / (d.params.size / (1024 * 1024)) }))
+
+  // Group leaderboard by params ID - { id: [entries] }
+  const groups = data.reduce((groups, d) => {
+    groups[d.params.id] = (groups[d.params.id] || []).concat(d)
+    return groups
+  }, {})
+
+  // [[leaderboard], [leaderboard]]
+  return Object.values(groups)
+    .filter(l => l.length > 1) // Not really a leaderboard if only 1 person...
+    .sort((a, b) => { // Sort by "top" boards then popular boards
+      const aIndex = TOP_BOARD_PARAM_IDS.indexOf(a[0].params.id)
+      const bIndex = TOP_BOARD_PARAM_IDS.indexOf(b[0].params.id)
+      if (aIndex > -1 && bIndex > -1) return aIndex - bIndex
+      if (aIndex > -1 || bIndex > -1) return 1
+      return b.length - a.length
+    })
+    .map(board => board.sort((a, b) => a.secondsPerMBTime - b.secondsPerMBTime))
+}
+
+class LeaderboardList extends Component {
+  state = { expanded: false }
+
+  componentDidMount () {
+    const refresh = async () => {
+      try {
+        const res = await fetch(API_URL)
+        if (!res.ok) throw new Error(`unexpected status ${res.status}`)
+        this.setState({ boardData: await res.json() })
+      } catch (err) {
+        console.error('failed to fetch leaderboard data', err)
+      } finally {
+        this._refreshTimeoutId = setTimeout(refresh, REFRESH_INTERVAL)
+      }
+    }
+    refresh()
+  }
+
+  componentWillUnmount () {
+    clearTimeout(this._refreshTimeoutId)
+  }
+
+  render () {
+    const { boardData, expanded } = this.state
+
+    if (!boardData) return <p>Loading...</p>
+
+    const all = processBoardData(boardData)
+    const top = all.slice(0, TOP_BOARD_PARAM_IDS.length)
+    const rest = all.slice(TOP_BOARD_PARAM_IDS.length)
+
+    const onExpand = () => this.setState({ expanded: true })
+    const onCollapse = () => this.setState({ expanded: false })
+
+    return (
+      <Fragment>
+        <div className='mw7 pl3 center pb2 cf'>
+          <h2 className='f4 f3-m f3-l mv3 pl4-m pl4-l tc tl-m tl-l montserrat fw2 ttu fl-m fl-l'>Leaderboards</h2>
+        </div>
+        <div className='mw7 pl3 center pb2 cf'>
+          {top.map(l => <Leaderboard entries={l} />)}
+        </div>
+        {rest.length ? (
+          <div className='flex items-center mt4 mb5 ph3'>
+            <div className='flex-auto'><hr className={`black-${expanded ? '20' : '10'} b--solid`} /></div>
+            <div className='flex-none mh3'>
+              <button
+                type='button'
+                className='montserrat f6 fw2 gray bw0 br3 ph3 pv2 bg-black-10 hover-bg-black-30 pointer'
+                onClick={expanded ? onCollapse : onExpand}>
+                {expanded ? 'Hide other leaderboards' : 'Show all leaderboards' }
+              </button>
+            </div>
+            <div className='flex-auto'><hr className={`black-${expanded ? '20' : '10'} b--solid`} /></div>
+          </div>
+        ) : null}
+        <div className='mw7 pl3 center pb2 cf'>
+          {expanded ? rest.map(l => <Leaderboard entries={l} />) : null}
+        </div>
+      </Fragment>
+    )
+  }
+}
+
+export default LeaderboardList

--- a/src/LeaderboardList.js
+++ b/src/LeaderboardList.js
@@ -92,9 +92,11 @@ class LeaderboardList extends Component {
             <div className='flex-auto'><hr className={`black-${expanded ? '20' : '10'} b--solid`} /></div>
           </div>
         ) : null}
-        <div className='mw7 pl3 center pb2 cf'>
-          {expanded ? rest.map(l => <Leaderboard entries={l} />) : null}
-        </div>
+        {rest.length && expanded ? (
+          <div className='mw7 pl3 center pb2 cf'>
+            {rest.map(l => <Leaderboard entries={l} />)}
+          </div>
+        ) : null}
       </Fragment>
     )
   }


### PR DESCRIPTION
Shows these 4 leaderboards at the top in this order:

* Zigzag 10 MiB
* DrgPoRep 10 MiB
* Zigzag 1 GiB
* DrgPoRep 1 GiB

The other leaderboards are ordered by popularity and accessible by a new button at the bottom of the page.

<img width="1310" alt="screenshot 2019-03-08 at 12 02 20" src="https://user-images.githubusercontent.com/152863/54027765-885bd700-419a-11e9-99b3-eb93fe1f91ab.png">
<img width="1310" alt="screenshot 2019-03-08 at 12 02 30" src="https://user-images.githubusercontent.com/152863/54027770-8a259a80-419a-11e9-90a1-52c14c63062c.png">

resolves https://github.com/filecoin-project/replication-game/issues/39